### PR TITLE
Update GreedyAtlasMain.cxx

### DIFF
--- a/Code/Applications/Greedy/GreedyAtlasMain.cxx
+++ b/Code/Applications/Greedy/GreedyAtlasMain.cxx
@@ -18,6 +18,7 @@
 #include "WeightedImageSet.h"
 #include "ImagePreprocessor.h"
 #include "CmdLineParser.h"
+#include <unistd.h>
 
 #ifdef CUDA_ENABLED
 #include "GreedyAtlasThreadGPU.h"


### PR DESCRIPTION
BUG: When compiling with gcc 4.8.2, the following error was happening:
error: ‘gethostname’ was not declared in this scope
   gethostname(hostname, HOSTNAME_SIZE);
